### PR TITLE
Added custom ID option

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -70,6 +70,15 @@ export default function App() {
       >
         <Header />
         <Boards />
+        <div className="gameID">
+        {game.practice ? (
+          <p>
+          GameID = {game.id}
+          </p>
+        ) : (
+          <div></div>
+        )}
+        </div>
         <Keyboard hidden={gameOver} />
         <Result hidden={!gameOver} />
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -78,6 +78,7 @@ export default function Header() {
   // button to be activated again
   const practiceRef = useRef<HTMLButtonElement>(null);
   const newRef = useRef<HTMLButtonElement>(null);
+  const customRef = useRef<HTMLButtonElement>(null);
   const backRef = useRef<HTMLButtonElement>(null);
   const handlePracticeClick = () => {
     practiceRef.current?.blur();
@@ -93,6 +94,19 @@ export default function Header() {
     if (!res) return;
     const id = MersenneTwister().u32();
     dispatch(startGame({ id, practice: true }));
+  };
+  const handleCustomClick = () => {
+    customRef.current?.blur();
+    const res = window.confirm(
+      "Are you sure you want to start a new custom practice duotrigordle?\n" +
+        "(Your current progress will be lost)"
+    );
+    if (!res) return;
+    const user_chosen_id = window.prompt("Choose ID","0");
+    if (user_chosen_id != null){
+      const id = parseInt(user_chosen_id);
+      dispatch(startGame({id, practice: true }));
+    }
   };
   const handleBackClick = () => {
     backRef.current?.blur();
@@ -136,12 +150,16 @@ export default function Header() {
             <button ref={newRef} onClick={handleNewClick}>
               New
             </button>
+            <button ref={customRef} onClick={handleCustomClick}>
+              Custom
+            </button>
           </>
         ) : (
           <>
             <button ref={practiceRef} onClick={handlePracticeClick}>
               Practice
             </button>
+            <div></div>
             <div></div>
           </>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --guess-text-red: red;
   --app-width: min(100vw, var(--app-max-width));
   --app-max-width: 600px;
+  --gray: rgb(100,100,100);
 }
 html {
   height: 100%;
@@ -74,7 +75,7 @@ button {
 }
 .row-1 {
   display: grid;
-  grid-template-columns: auto auto 1fr auto auto auto;
+  grid-template-columns: auto auto auto 1fr auto auto auto;
   column-gap: 8px;
   align-items: center;
   justify-content: center;
@@ -155,6 +156,9 @@ button {
   position: absolute;
 }
 
+.gameID {
+ color: var(--gray);
+}
 /* Keyboard */
 .keyboard {
   display: grid;


### PR DESCRIPTION
I wanted to be able to play with a friend, and do the same practice game. This pull request adds the two essential elements for this functionality, both of which only appear in Practice mode.

1. There is now a Custom button at the top, which prompts the user to choose a Game ID to play.
2. There is now a Game ID readout placed above the keyboard. It is displayed in gray so as to be minimally intrusive in the rest of the game's style and not stick out.

Due to adding the extra button in the upper left, "Practice Duotrigordle" now appears on two lines, but I think this is an acceptable adjustment.

Please feel free to iterate on this concept as you please - it's certainly reasonable to play around with the layout a bit more and make things different, if my changes clash with original design intents. In any case, this feature is nice to have.