### PR TITLE
Work around Safari animation bug on completed boards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,10 @@ button {
   background: var(--white);
 }
 
+.game:not(.game.hide-completed-boards) .board {
+  transform: translateZ(0);
+}
+
 .game:not(.game.hide-completed-boards) .board.complete {
   filter: contrast(0.5) brightness(0.5);
   transition: filter 150ms ease-out;
@@ -139,6 +143,10 @@ button {
 
 .game.hide-completed-boards:not(.animate-hiding) .board.complete {
   display: none;
+}
+
+.game.hide-completed-boards.animate-hiding .board {
+  transform: translateZ(0);
 }
 
 .game.hide-completed-boards.animate-hiding .board.complete {


### PR DESCRIPTION
In Safari, especially on iPhone, scrolling around the page looks flickery and glitchy, when you have completed boards visible.  Worse, when you complete a board, the animation causes the page to stall for several seconds -- and then you don't even see the animation.

This appears to be triggered by the `filter` property on completed boards.

Workaround: if we force 3D acceleration by adding `translateZ(0)` to each board, all is well. There are no glitches, the animation looks good, and the app doesn't stall. It's also more responsive when entering letters.

(There is no need to do this when "hide completed boards" is on, but "animate hiding" is off, so we don't.)

Fixes #24.