### PR TITLE
Keyboard letter text shouldn't be selectable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -224,6 +224,7 @@ button {
   justify-content: center;
   border: 1px solid white;
   font-size: calc(var(--app-width) / 20);
+  user-select: none;
 }
 .key.enter-1 {
   border-bottom: none;


### PR DESCRIPTION
On Safari on iPhone or iPad, an accidental long-press on a keyboard key selects the text in it. Don't allow selection there.